### PR TITLE
Fix team order at index and scoreboard page

### DIFF
--- a/web server/index.php
+++ b/web server/index.php
@@ -55,7 +55,7 @@ if (isset($_GET["page"])) {
         while($row = $result->fetch_assoc()) {
             $half = ($row["team_2"] + $row["team_3"]) / 2;
 
-            if ($row["team_2"] > $half) {
+            if ($row["team_3"] > $half) {
                 $image = 'ct_icon.png';
             } elseif ($row["team_2"] == $half && $row["team_3"] == $half) {
                 $image = 'tie_icon.png';
@@ -69,7 +69,7 @@ if (isset($_GET["page"])) {
             <a href="scoreboard.php?id='.$row["match_id"].'">
                 <div class="card match-card center" data-bs-hover-animate="pulse" style="margin-top:35px;"><img class="card-img w-100 d-block matches-img rounded-borders" style="background-image:url(&quot;'.$map_img.'&quot;);height:150px;">
                     <div class="card-img-overlay">
-                        <h4 class="text-white float-left" style="font-size:70px;margin-top:15px;">'.$row['team_2'].':'.$row['team_3'].'</h4><img class="float-right" src="assets/img/icons/'.$image.'?h=4347d1d6c5595286f4b1acacc902fedd" style="width:110px;"></div>
+                        <h4 class="text-white float-left" style="font-size:70px;margin-top:15px;">'.$row['team_3'].':'.$row['team_2'].'</h4><img class="float-right" src="assets/img/icons/'.$image.'?h=4347d1d6c5595286f4b1acacc902fedd" style="width:110px;"></div>
                 </div>
             </a>';
         }

--- a/web server/scoreboard.php
+++ b/web server/scoreboard.php
@@ -46,8 +46,8 @@ if (isset($_GET["id"])) {
                     $kdr = 0;
                 }
                 if ($row["team"] == 2) {
-                    $t_score = $row["team_3"];
-                    $t_name = $row["teamname_2"];
+                    $t_score = $row["team_2"];
+                    $t_name = $row["teamname_1"];
                     if ($t_name == NULL) {
                         $t_name = "Terrorists";
                     }
@@ -63,8 +63,8 @@ if (isset($_GET["id"])) {
                         <td>'.$row["ping"].'</td>
                     </tr>';
                 } elseif ($row["team"] == 3) {
-                    $ct_score = $row["team_2"];
-                    $ct_name = $row["teamname_1"];
+                    $ct_score = $row["team_3"];
+                    $ct_name = $row["teamname_2"];
                     if ($ct_name == NULL) {
                         $ct_name = "Counter-Terrorists";
                     }

--- a/web server/scoreboard.php
+++ b/web server/scoreboard.php
@@ -47,7 +47,7 @@ if (isset($_GET["id"])) {
                 }
                 if ($row["team"] == 2) {
                     $t_score = $row["team_3"];
-                    $t_name = $row["teamname_1"];
+                    $t_name = $row["teamname_2"];
                     if ($t_name == NULL) {
                         $t_name = "Terrorists";
                     }
@@ -64,7 +64,7 @@ if (isset($_GET["id"])) {
                     </tr>';
                 } elseif ($row["team"] == 3) {
                     $ct_score = $row["team_2"];
-                    $ct_name = $row["teamname_2"];
+                    $ct_name = $row["teamname_1"];
                     if ($ct_name == NULL) {
                         $ct_name = "Counter-Terrorists";
                     }


### PR DESCRIPTION
`teamname_1` = CT, `teamname_2` = T

Edit:
`team_2` score is T score and `team_3` score is CT score by the end of the match.
If you start as a CT, and win as a T, `teamname_1` should be used as a winning team (T) name.