### PR TITLE
Real UTF-8 Unicode charset

### DIFF
--- a/game server/sqlmatch.sp
+++ b/game server/sqlmatch.sp
@@ -27,7 +27,7 @@ public void OnPluginStart()
 	Format(buffer, sizeof(buffer), "%s teamname_2 varchar(64) NOT NULL,", buffer);
 	Format(buffer, sizeof(buffer), "%s map varchar(128) NOT NULL,", buffer);
 	Format(buffer, sizeof(buffer), "%s PRIMARY KEY (match_id),", buffer);
-	Format(buffer, sizeof(buffer), "%s UNIQUE KEY match_id (match_id));", buffer);
+	Format(buffer, sizeof(buffer), "%s UNIQUE KEY match_id (match_id)) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;", buffer);
 
 	if (!SQL_FastQuery(db, buffer))
 	{
@@ -47,7 +47,7 @@ public void OnPluginStart()
 	Format(buffer, sizeof(buffer), "%s assists int(11) NOT NULL,", buffer);
 	Format(buffer, sizeof(buffer), "%s deaths int(11) NOT NULL,", buffer);
 	Format(buffer, sizeof(buffer), "%s mvps int(11) NOT NULL,", buffer);
-	Format(buffer, sizeof(buffer), "%s score int(11) NOT NULL);", buffer);
+	Format(buffer, sizeof(buffer), "%s score int(11) NOT NULL) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;", buffer);
 
 	if (!SQL_FastQuery(db, buffer))
 	{

--- a/web server/config.php
+++ b/web server/config.php
@@ -30,4 +30,6 @@ $conn = new mysqli($servername, $username, $password, $dbname);
 if ($conn->connect_error) {
     die("Connection failed: " . $conn->connect_error);
 }
+$conn->set_charset("utf8mb4");
+$conn->query("SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci");
 ?>


### PR DESCRIPTION
Not fully tested.

Probably the `unicode2html()` function needs to be edited in `scoreboard.php`, or even omitted if the [DB settings/connections](https://www.php.net/manual/en/mysqli.set-charset.php#121647) are correct.

If you already have the database, probably have to alter it's charset and collate to work nicely with UTF-8 unicode:
```
ALTER DATABASE databasename CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
ALTER TABLE sql_matches_scoretotal CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
ALTER TABLE sql_matches CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
```
Some older strings may get messed up, but the new ones will be correct.

Note: MySQL 5.5.2 or older didn't support 4-byte UTF-8, use `utf8` instead of `utf8mb4`.